### PR TITLE
Spatial query for Observation.

### DIFF
--- a/ddl/fits-test-data.ddl
+++ b/ddl/fits-test-data.ddl
@@ -10,7 +10,7 @@ select fits.add_site('TN1', 'TEST2', $$Test site 2$$, 172.79019, -42.21496, -111
 -- Add another site TEST2 but in the TN2 network
 select fits.add_site('TN2', 'TEST2', $$Test site 2$$, 172.79019, -42.21496, -999.99, 0.0);
 
-select fits.add_site('TN1', 'TEST3', $$Test site 2$$, 172.79019, -42.21496, -999.99, 0.0);
+select fits.add_site('TN1', 'TEST3', $$Test site 3$$, 175.79019, -42.21496, -999.99, 0.0);
 
 insert into fits.unit(symbol, name) VALUES ('m', 'metre');
 insert into fits.unit(symbol, name) VALUES ('K', 'Kelvin');

--- a/ddl/fits-test-data.ddl
+++ b/ddl/fits-test-data.ddl
@@ -10,6 +10,8 @@ select fits.add_site('TN1', 'TEST2', $$Test site 2$$, 172.79019, -42.21496, -111
 -- Add another site TEST2 but in the TN2 network
 select fits.add_site('TN2', 'TEST2', $$Test site 2$$, 172.79019, -42.21496, -999.99, 0.0);
 
+select fits.add_site('TN1', 'TEST3', $$Test site 2$$, 172.79019, -42.21496, -999.99, 0.0);
+
 insert into fits.unit(symbol, name) VALUES ('m', 'metre');
 insert into fits.unit(symbol, name) VALUES ('K', 'Kelvin');
 
@@ -18,10 +20,12 @@ insert into fits.type (typeID, name, description, unitPK) VALUES ('t2', 'Type 1'
 
 insert into fits.method (methodID, name, description, reference) VALUES ('m1', 'Method 1', 'Test data method 1', 'a link to more information about method 1');
 insert into fits.method (methodID, name, description, reference) VALUES ('m2', 'Method 2', 'Test data method 2', 'a link to more information about method 2');
+insert into fits.method (methodID, name, description, reference) VALUES ('m3', 'Method 3', 'Test data method 3', 'a link to more information about method 3');
 
 -- Being lazy with sequence values and assuming these rows are being insterted into a clean freshly created DB.
 insert into fits.type_method (typePK, methodPK) VALUES (1,1);	
 insert into fits.type_method (typePK, methodPK) VALUES (1,2);
+insert into fits.type_method (typePK, methodPK) VALUES (1,3);
 insert into fits.type_method (typePK, methodPK) VALUES (2,1);
 
 insert into fits.system(systemID, description) VALUES ('none', 'No external system reference');	
@@ -44,3 +48,6 @@ select fits.add_observation('TN1', 'TEST2', 't1', 'm2', 'none', 'none',  '2000-0
 select fits.add_observation('TN1', 'TEST2', 't1', 'm2', '0001', 'lab',  '2001-01-08T12:00:00.000000Z'::timestamptz, 9.02, 0.1);
 select fits.add_observation('TN1', 'TEST2', 't1', 'm1', '0001', 'lab',  '2001-01-08T12:00:00.000000Z'::timestamptz, 9.12, 0.01);
 select fits.add_observation('TN1', 'TEST2', 't2', 'm1', '0001', 'lab',  '2001-01-08T12:00:00.000000Z'::timestamptz, 9.12, 0.01);
+
+-- m3 for t1 at TEST3 only
+select fits.add_observation('TN1', 'TEST3', 't1', 'm3', '0001', 'lab',  '2001-01-08T12:00:00.000000Z'::timestamptz, 9.12, 0.01);

--- a/doc_strings.go
+++ b/doc_strings.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"html/template"
+)
+
+const (
+	optDoc    template.HTML = `<mark>Optional.</mark>`
+	withinDoc template.HTML = `Only return sites that fall within the polygon (uses <a href="http://postgis.net/docs/ST_Within.html">ST_Within</a>).  The polygon is
+		defined in <a href="http://en.wikipedia.org/wiki/Well-known_text">WKT</a> format
+		(WGS84).  The polygon must be topologically closed.  Spaces can be replaced with <code>+</code> or <a href="http://en.wikipedia.org/wiki/Percent-encoding">URL encoded</a> as <code>%20</code> e.g., 
+		<code>POLYGON((177.18+-37.52,177.19+-37.52,177.20+-37.53,177.18+-37.52))</code>.`
+	typeIDDoc    template.HTML = `A type identifier for observations e.g., <code>e</code>.`
+	methodIDDoc  template.HTML = `A valid method identifier for observation type e.g., <code>doas-s</code>.`
+	grelDoc      template.HTML = `Site ground relationship (m).  Sites above ground level have a negative ground relationship.`
+	heightDoc    template.HTML = `Site height (m).`
+	nameDoc      template.HTML = `Site name e.g, <code>White Island Volcano</code>.`
+	networkIDDoc template.HTML = `Network identifier e.g., <code>VO</code>.`
+	siteIDDoc    template.HTML = `Site identifier e.g., <code>WI000</code>.`
+	obsDTDoc     template.HTML = `The date-time of the observation in <a href="http://en.wikipedia.org/wiki/ISO_8601">ISO8601</a> format, UTC time zone.`
+	obsValDoc    template.HTML = `The observation value.`
+	obsErrDoc    template.HTML = `The observation error.  0 is used for an unknown error.`
+)
+
+var siteProps = map[string]template.HTML{
+	"groundRelationship": grelDoc,
+	"height":             heightDoc,
+	"name":               nameDoc,
+	"neworkID":           networkIDDoc,
+	"siteID":             siteIDDoc,
+}

--- a/method.go
+++ b/method.go
@@ -20,15 +20,15 @@ var methodQueryD = &apidoc.Query{
 	Description: "Look up method information.",
 	Example:     "/method?typeID=e",
 	ExampleHost: exHost,
-	URI:         "/method?typeID=(typeID)",
+	URI:         "/method?[typeID=(typeID)]",
 	Params: map[string]template.HTML{
-		"typeID": `a valid type identifier.  Optional.`,
+		"typeID": optDoc + `  ` + typeIDDoc,
 	},
 	Props: map[string]template.HTML{
-		"description": `a description of the method.`,
-		"methodID":    `the method identifier.`,
-		"name":        `the method name.`,
-		"reference":   `a link to further information about the method.`,
+		"description": `A description of the method e.g., <code>Bernese v5.0 GNS processing software</code>.`,
+		"methodID":    methodIDDoc,
+		"name":        `The method name e.g., <code>Bernese v5.0</code>.`,
+		"reference":   `A link to further information about the method.`,
 	},
 }
 

--- a/observation.go
+++ b/observation.go
@@ -20,6 +20,7 @@ var observationDoc = apidoc.Endpoint{Title: "Observation",
 	Description: `Look up observations.`,
 	Queries: []*apidoc.Query{
 		new(observationQuery).Doc(),
+		new(spatialObs).Doc(),
 	},
 }
 

--- a/observation.go
+++ b/observation.go
@@ -30,19 +30,18 @@ var observationQueryD = &apidoc.Query{
 	Description: "Observations as CSV",
 	Example:     "/observation?typeID=e&siteID=HOLD&networkID=CG",
 	ExampleHost: exHost,
-	URI:         "/observation?typeID=(typeID)&siteID=(siteID)&networkID=(networkID)",
+	URI:         "/observation?typeID=(typeID)&siteID=(siteID)&networkID=(networkID)&[days=int]&[methodID=(methodID)]",
 	Params: map[string]template.HTML{
-		"typeID":    `typeID for the observations to be retrieved e.g., <code>e</code>.`,
-		"siteID":    `the siteID to retrieve observations for e.g., <code>HOLD</code>`,
-		"networkID": `the networkID for the siteID e.g., <code>CG</code>.`,
-		"days":      `Optional.  The number of days of data to select before now e.g., <code>250</code>.  Maximum value is 365000.`,
-		"methodID": `Optional. Return only observations where the typeID has the provided methodID.  methodID must be a valid method
-		for the typeID.`,
+		"typeID":    typeIDDoc,
+		"siteID":    siteIDDoc,
+		"networkID": networkIDDoc,
+		"days":      optDoc + `  The number of days of data to select before now e.g., <code>250</code>.  Maximum value is 365000.`,
+		"methodID":  optDoc + `  ` + methodIDDoc + `  typeID must be specified as well.`,
 	},
 	Props: map[string]template.HTML{
-		"column 1": `The date-time of the observation in <a href="http://en.wikipedia.org/wiki/ISO_8601">ISO8601</a> format, UTC time zone.`,
-		"column 2": `The observation value.`,
-		"column 3": `The observation error.  0 is used for an unknown error.`,
+		"column 1": obsDTDoc,
+		"column 2": obsValDoc,
+		"column 3": obsErrDoc,
 	},
 }
 

--- a/plot.go
+++ b/plot.go
@@ -26,9 +26,9 @@ var plotQueryD = &apidoc.Query{
 	Title:       "Observations SVG",
 	Description: "Plot observations as Scalable Vector Graphic (SVG)",
 	Discussion: `<p><b><i>Caution:</i></b> these plots should be used with caution
-	and some understanding of the underlying data.  FITS data is unevenly sampled and often has a wider time range than
-	can be represented accurately in these plots.  No down sampling of any kind is attempted for plotting.  Data points
-	are joined with straight lines.  There is potential for artifacts or for signal to be obscured.  If you think you have seen 
+	and some understanding of the underlying data.  FITS data is often unevenly sampled.  The requested data range may not be 
+	accurately represented at the resolution of these plots.  No down sampling of any kind is attempted for plotting.  Data points
+	are joined with straight lines.  There is potential for signal to be obscured or visual artifacts created.  If you think you have seen 
 	something interesting then please use the raw CSV observations and more sophisticated analysis techniques to confirm your observations.</p>
 	<p>
 	<img src="/plot?networkID=LI&siteID=GISB&typeID=e" style="width: 100% \9" class="img-responsive" />
@@ -49,14 +49,14 @@ var plotQueryD = &apidoc.Query{
 	<br />Not all observations have an associated error estimate.
 	</p>
             `,
-	URI: "/plot?typeID=(typeID)&siteID=(siteID)&networkID=(networkID)[&days=int][&yrange=float64]",
+	URI: "/plot?typeID=(typeID)&siteID=(siteID)&networkID=(networkID)&[days=int]&[yrange=float64]",
 	Params: map[string]template.HTML{
-		"typeID":    `typeID for the observations to be retrieved e.g., <code>e</code>.`,
-		"siteID":    `the siteID to retrieve observations for e.g., <code>HOLD</code>`,
-		"networkID": `the networkID for the siteID e.g., <code>CG</code>.`,
-		"days": `Optional.  The number of days of data to display before now e.g., <code>250</code>.  Sets the range of the 
+		"typeID":    typeIDDoc,
+		"siteID":    siteIDDoc,
+		"networkID": networkIDDoc,
+		"days": optDoc + `  The number of days of data to display before now e.g., <code>250</code>.  Sets the range of the 
 		x-axis which may not be the same as the data.  Maximum value is 365000.`,
-		"yrange": `Optional.  Defines the y-axis range as the positive and negative range about the mid point of the minimum and maximum
+		"yrange": optDoc + `  Defines the y-axis range as the positive and negative range about the mid point of the minimum and maximum
 		data values.  For example if the minimum and maximum y values in the data selection are 10 and 30 and the yrange is <code>40</code> then
 		the y-axis range will be -20 to 60.  yrange must be > 0`,
 	},

--- a/routes.go
+++ b/routes.go
@@ -53,11 +53,11 @@ func router(w http.ResponseWriter, r *http.Request) {
 			api.Serve(q, w, r)
 		}
 	case r.URL.Path == "/site" && (accept == web.V1GeoJSON || latest):
-		if len(r.URL.Query()) == 1 {
-			q := &siteTypeQuery{}
+		if r.URL.Query().Get("siteID") != "" {
+			q := &siteQuery{}
 			api.Serve(q, w, r)
 		} else {
-			q := &siteQuery{}
+			q := &siteTypeQuery{}
 			api.Serve(q, w, r)
 		}
 	case r.URL.Path == "/type" && (accept == web.V1JSON || latest):

--- a/routes.go
+++ b/routes.go
@@ -45,8 +45,13 @@ func router(w http.ResponseWriter, r *http.Request) {
 		q := &plotQuery{}
 		api.Serve(q, w, r)
 	case r.URL.Path == "/observation" && (accept == web.V1CSV || latest):
-		q := &observationQuery{}
-		api.Serve(q, w, r)
+		if r.URL.Query().Get("siteID") != "" {
+			q := &observationQuery{}
+			api.Serve(q, w, r)
+		} else {
+			q := &spatialObs{}
+			api.Serve(q, w, r)
+		}
 	case r.URL.Path == "/site" && (accept == web.V1GeoJSON || latest):
 		if len(r.URL.Query()) == 1 {
 			q := &siteTypeQuery{}

--- a/routes_test.go
+++ b/routes_test.go
@@ -101,9 +101,9 @@ func TestRoutes(t *testing.T) {
 
 	r.Test(ts, t)
 
-	// Routes that should 404
+	// CSV routes that should 404
 	r = webtest.Route{
-		Accept:     web.V1JSON,
+		Accept:     web.V1CSV,
 		Content:    web.ErrContent,
 		Cache:      web.MaxAge10,
 		Surrogate:  web.MaxAge10,

--- a/routes_test.go
+++ b/routes_test.go
@@ -41,6 +41,9 @@ func TestRoutes(t *testing.T) {
 	r.Add("/observation?typeID=t1&siteID=TEST1&networkID=TN1&methodID=m1&days=400")
 	r.Add("/observation?typeID=t1&siteID=TEST1&networkID=TN1&days=400")
 	r.Add("/observation?typeID=t1&start=2010-11-24T00:00:00Z&days=2")
+	r.Add("/observation?typeID=t1&start=2010-11-24T00:00:00Z&days=2&methodID=m1")
+	r.Add("/observation?typeID=t1&start=2010-11-24T00:00:00Z&days=2&within=POLYGON((170.18+-37.52,177.19+-47.52,177.20+-37.53,170.18+-37.52))")
+	r.Add("/observation?typeID=t1&start=2010-11-24T00:00:00Z&days=2&within=POLYGON((170.18+-37.52,177.19+-47.52,177.20+-37.53,170.18+-37.52))&methodID=m1")
 
 	r.Test(ts, t)
 
@@ -112,6 +115,8 @@ func TestRoutes(t *testing.T) {
 	r.Add("/observation?typeID=t1&siteID=TEST1&networkID=NO")
 	r.Add("/observation?typeID=t1&siteID=TEST1&networkID=TN1&methodID=m100")
 	r.Add("/observation?typeID=t1&siteID=TEST1&networkID=TN1&methodID=m100&days=100")
+	r.Add("/observation?typeID=t1&start=2010-11-24T00:00:00Z&days=2&methodID=m100")
+	r.Add("/observation?typeID=t1&start=2010-11-24T00:00:00Z&days=2&methodID=m100&within=POLYGON((170.18+-37.52,177.19+-47.52,177.20+-37.53,170.18+-37.52))")
 
 	// r.Test(ts, t)
 

--- a/routes_test.go
+++ b/routes_test.go
@@ -22,6 +22,7 @@ func TestRoutes(t *testing.T) {
 		TestAccept: false,
 	}
 	r.Add("/site?typeID=t1")
+	r.Add("/site?typeID=t1&methodID=m1")
 	r.Add("/site")
 	r.Add("/site?siteID=TEST1&networkID=TN1")
 

--- a/routes_test.go
+++ b/routes_test.go
@@ -38,6 +38,7 @@ func TestRoutes(t *testing.T) {
 	}
 	r.Add("/observation?typeID=t1&siteID=TEST1&networkID=TN1")
 	r.Add("/observation?typeID=t1&siteID=TEST1&networkID=TN1&days=400")
+	r.Add("/observation?typeID=t1&start=2010-11-24T00:00:00Z&days=2")
 
 	r.Test(ts, t)
 
@@ -152,6 +153,11 @@ func TestRoutes(t *testing.T) {
 	}
 	r.Add("/")
 	r.Add("/bob")
+	r.Add("/observation?typeID=t1&start=2010-11-24T00:00:00Z&days=0")
+	r.Add("/observation?typeID=t1&start=2010-11-24T00:00:00Z&days=8")
+	r.Add("/observation?typeID=t1&start=2010-11-24T00:00:00Z&days=2&srsName=EPSG:999999")
+	r.Add("/observation?typeID=t1&start=2010-11-24T00:00:00Z&days=2&within=POLYGON((177.18+-37.52,177.19+-37.52,177.20+-37.53))")             // no enough points
+	r.Add("/observation?typeID=t1&start=2010-11-24T00:00:00Z&days=2&within=POLYGON((177.18+-37.52,177.19+-37.52,177.20+-37.53,178.0+-34.5))") // doesn't close
 
 	r.Test(ts, t)
 }

--- a/routes_test.go
+++ b/routes_test.go
@@ -22,6 +22,7 @@ func TestRoutes(t *testing.T) {
 		TestAccept: false,
 	}
 	r.Add("/site?typeID=t1")
+	r.Add("/site")
 	r.Add("/site?siteID=TEST1&networkID=TN1")
 
 	r.Test(ts, t)

--- a/routes_test.go
+++ b/routes_test.go
@@ -37,6 +37,8 @@ func TestRoutes(t *testing.T) {
 		TestAccept: false,
 	}
 	r.Add("/observation?typeID=t1&siteID=TEST1&networkID=TN1")
+	r.Add("/observation?typeID=t1&siteID=TEST1&networkID=TN1&methodID=m1")
+	r.Add("/observation?typeID=t1&siteID=TEST1&networkID=TN1&methodID=m1&days=400")
 	r.Add("/observation?typeID=t1&siteID=TEST1&networkID=TN1&days=400")
 	r.Add("/observation?typeID=t1&start=2010-11-24T00:00:00Z&days=2")
 
@@ -108,6 +110,8 @@ func TestRoutes(t *testing.T) {
 	r.Add("/observation?typeID=t1&NO=TEST1&networkID=TN1")
 	r.Add("/observation?typeID=t1&siteID=NO&networkID=TN1")
 	r.Add("/observation?typeID=t1&siteID=TEST1&networkID=NO")
+	r.Add("/observation?typeID=t1&siteID=TEST1&networkID=TN1&methodID=m100")
+	r.Add("/observation?typeID=t1&siteID=TEST1&networkID=TN1&methodID=m100&days=100")
 
 	// r.Test(ts, t)
 

--- a/routes_test.go
+++ b/routes_test.go
@@ -25,6 +25,9 @@ func TestRoutes(t *testing.T) {
 	r.Add("/site?typeID=t1&methodID=m1")
 	r.Add("/site")
 	r.Add("/site?siteID=TEST1&networkID=TN1")
+	r.Add("/site?within=POLYGON((170.18+-37.52,177.19+-47.52,177.20+-37.53,170.18+-37.52))")
+	r.Add("/site?typeID=t1&within=POLYGON((170.18+-37.52,177.19+-47.52,177.20+-37.53,170.18+-37.52))")
+	r.Add("/site?typeID=t1&methodID=m1&within=POLYGON((170.18+-37.52,177.19+-47.52,177.20+-37.53,170.18+-37.52))")
 
 	r.Test(ts, t)
 
@@ -134,6 +137,10 @@ func TestRoutes(t *testing.T) {
 	}
 	r.Add("/")
 	r.Add("/bob")
+	r.Add("/site?methodID=m1")
+	r.Add("/site?methodID=m1&within=POLYGON((170.18+-37.52,177.19+-47.52,177.20+-37.53,170.18+-37.52))")
+	r.Add("/site?within=POLYGON((170.18+-37.52,177.19+-47.52))")                             // not enough points
+	r.Add("/site?within=POLYGON((170.18+-37.52,177.19+-47.52,177.20+-37.53,178.18+-37.52))") // doesn't close
 
 	r.Test(ts, t)
 
@@ -167,7 +174,7 @@ func TestRoutes(t *testing.T) {
 	r.Add("/observation?typeID=t1&start=2010-11-24T00:00:00Z&days=0")
 	r.Add("/observation?typeID=t1&start=2010-11-24T00:00:00Z&days=8")
 	r.Add("/observation?typeID=t1&start=2010-11-24T00:00:00Z&days=2&srsName=EPSG:999999")
-	r.Add("/observation?typeID=t1&start=2010-11-24T00:00:00Z&days=2&within=POLYGON((177.18+-37.52,177.19+-37.52,177.20+-37.53))")             // no enough points
+	r.Add("/observation?typeID=t1&start=2010-11-24T00:00:00Z&days=2&within=POLYGON((177.18+-37.52,177.19+-37.52,177.20+-37.53))")             // not enough points
 	r.Add("/observation?typeID=t1&start=2010-11-24T00:00:00Z&days=2&within=POLYGON((177.18+-37.52,177.19+-37.52,177.20+-37.53,178.0+-34.5))") // doesn't close
 
 	r.Test(ts, t)

--- a/site.go
+++ b/site.go
@@ -37,22 +37,16 @@ var siteDoc = apidoc.Endpoint{Title: "Site",
 
 var siteQueryD = &apidoc.Query{
 	Accept:      web.V1GeoJSON,
-	Title:       "Site Information",
+	Title:       "Site",
 	Description: "Find information for individual sites.",
 	Example:     "/site?siteID=HOLD&networkID=CG",
 	ExampleHost: exHost,
 	URI:         "/site?siteID=(siteID)&networkID=(networkID)",
 	Params: map[string]template.HTML{
-		"siteID":    `the siteID to retrieve observations for e.g., <code>HOLD</code>`,
-		"networkID": `the networkID for the siteID e.g., <code>CG</code>.`,
+		"siteID":    siteIDDoc,
+		"networkID": networkIDDoc,
 	},
-	Props: map[string]template.HTML{
-		"groundRelationship": `the ground relationship (m) for the site.  Site above ground level have a negative ground relationship.`,
-		"height":             `the height of the site (m).`,
-		"name":               `the name of the site.`,
-		"neworkID":           `the identifier for the network the site is in.`,
-		"siteID":             `a short identifier for the site.`,
-	},
+	Props: siteProps,
 }
 
 type siteQuery struct {
@@ -96,27 +90,17 @@ func (q *siteQuery) Handle(w http.ResponseWriter, r *http.Request) {
 
 var siteTypeQueryD = &apidoc.Query{
 	Accept:      web.V1GeoJSON,
-	Title:       "Observation and Method",
-	Description: "Filter sites by observation type and method.",
+	Title:       "Sites",
+	Description: "Filter sites by observation type, method, and location.",
 	Example:     "/site?typeID=e",
 	ExampleHost: exHost,
-	URI:         "/site?typeID=(typeID)",
+	URI:         "/site?[typeID=(typeID)]&[methodID=(methodID)]&[within=POLYGON((...))]",
 	Params: map[string]template.HTML{
-		"typeID": `Optional.  Find sites with observations of type typeID e.g., <code>e</code>.`,
-		"methodID": `Optional. Return only observations where the typeID has the provided methodID.  methodID must be a valid method
-		for the typeID.`,
-		"within": `Optional.  Only return sites that fall within the polygon (uses <a href="http://postgis.net/docs/ST_Within.html">ST_Within</a>).  The polygon is
-		defined in <a href="http://en.wikipedia.org/wiki/Well-known_text">WKT</a> format
-		(WGS84).  The polygon must be topologically closed.  Spaces can be replaced with <code>+</code> or <a href="http://en.wikipedia.org/wiki/Percent-encoding">URL encoded</a> as <code>%20</code> e.g., 
-		<code>POLYGON((177.18+-37.52,177.19+-37.52,177.20+-37.53,177.18+-37.52))</code>.`,
+		"typeID":   optDoc + `  ` + typeIDDoc,
+		"methodID": optDoc + `  ` + methodIDDoc + `  typeID must be specified as well.`,
+		"within":   optDoc + `  ` + withinDoc,
 	},
-	Props: map[string]template.HTML{
-		"groundRelationship": `the ground relationship (m) for the site.  Sites above ground level have a negative ground relationship.`,
-		"height":             `the height of the site (m).`,
-		"name":               `the name of the site.`,
-		"neworkID":           `the identifier for the network the site is in.`,
-		"siteID":             `a short identifier for the site.`,
-	},
+	Props: siteProps,
 }
 
 type siteTypeQuery struct {

--- a/spatialObservations.go
+++ b/spatialObservations.go
@@ -1,0 +1,226 @@
+package main
+
+import (
+	"bytes"
+	"database/sql"
+	"github.com/GeoNet/app/web"
+	"github.com/GeoNet/app/web/api/apidoc"
+	"html/template"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+var spatialObsD = &apidoc.Query{
+	Accept:      web.V1CSV,
+	Title:       "Spatial Observation",
+	Description: "Spatial observations as CSV",
+	Example:     "/observation?typeID=CO2-flux-e&start=2010-11-24T00:00:00Z&days=2&srsName=EPSG:27200&within=POLYGON((177.18+-37.52,177.19+-37.52,177.20+-37.53,177.18+-37.52))",
+	ExampleHost: exHost,
+	URI:         "/observation?typeID=(typeID)&start=(ISO8601 date time)&days=(int)&srsName=(CRS)&within=POLYGON((...))",
+	Params: map[string]template.HTML{
+		"typeID": `typeID for the observations to be retrieved e.g., <code>e</code>.`,
+		"days":   `The number of days of data to select from the start e.g., <code>1</code>.  Range is 1-7.`,
+		"start":  `the date time in ISO8601 format for the start of the time window for the request e.g., <code>2014-01-08T12:00:00Z</code>.`,
+		"srsName": `Optional (default EPSG:4326). Specify the <a href="http://en.wikipedia.org/wiki/Spatial_reference_system">spatial reference system</a> to project site coordinates to e.g., <code>EPSG:27200</code>
+		(<a href="http://spatialreference.org/ref/epsg/nzgd49-new-zealand-map-grid/">New Zealand Map Grid</a>).  
+		Site locations are stored as a geography.  For projection they are cast to a geometry and then projected using 
+		<a href ="http://postgis.net/docs/ST_Transform.html">ST_Transform</a>.  Behaviour of projection is not defined outside the bounds of the SRS.  
+		For further details please refer to the PostGis manual: <a href="http://postgis.org/docs/using_postgis_dbmanagement.html#spatial_ref_sys">4.3.1. The SPATIAL_REF_SYS Table and Spatial Reference Systems</a>.`,
+		"within": `Optional.  Only return sites that fall within the polygon (uses <a href="http://postgis.net/docs/ST_Within.html">ST_Within</a>).  The polygon is
+		defined in <a href="http://en.wikipedia.org/wiki/Well-known_text">WKT</a> format
+		(WGS84).  The polygon must be topologically closed.  Spaces can be replaced with <code>+</code> or <a href="http://en.wikipedia.org/wiki/Percent-encoding">URL encoded</a> as <code>%20</code> e.g., 
+		<code>POLYGON((177.18+-37.52,177.19+-37.52,177.20+-37.53,177.18+-37.52))</code>.`,
+	},
+	Props: map[string]template.HTML{
+		"column 1": `The networkID for the siteID e.g., <code>VO</code>.`,
+		"column 2": `The siteID  e.g., <code>WI034</code>.`,
+		"column 3": `The longitude (X) of the observation site.`,
+		"column 4": `The latitude (Y) of the observation site.`,
+		"column 5": `The height of the site (m).`,
+		"column 6": `The ground relationship (m) for the site.  Sites above ground level have a negative ground relationship.`,
+		"column 7": `The date-time of the observation in <a href="http://en.wikipedia.org/wiki/ISO_8601">ISO8601</a> format, UTC time zone.`,
+		"column 8": `The observation value.`,
+		"column 9": `The observation error.  0 is used for an unknown error.`,
+	},
+}
+
+type spatialObs struct {
+	typeID            string
+	days              int
+	start, end        time.Time
+	srsName, authName string
+	srid              int
+	within            string
+}
+
+func (q *spatialObs) Doc() *apidoc.Query {
+	return spatialObsD
+}
+
+func (q *spatialObs) Validate(w http.ResponseWriter, r *http.Request) bool {
+	// values needed for all queries
+	if !web.ParamsExist(w, r, "typeID", "days", "start") {
+		return false
+	}
+
+	rl := r.URL.Query()
+
+	var err error
+	q.days, err = strconv.Atoi(rl.Get("days"))
+	if err != nil || q.days > 7 || q.days <= 0 {
+		web.BadRequest(w, r, "Invalid days query param.")
+		return false
+	}
+
+	q.start, err = time.Parse(time.RFC3339, rl.Get("start"))
+	if err != nil {
+		web.BadRequest(w, r, "Invalid start query param.")
+		return false
+	}
+
+	q.end = q.start.Add(time.Duration(q.days) * time.Hour * 24)
+
+	if rl.Get("srsName") != "" {
+		q.srsName = rl.Get("srsName")
+		srs := strings.Split(q.srsName, ":")
+		if len(srs) != 2 {
+			web.BadRequest(w, r, "Invalid srsName.")
+			return false
+		}
+		q.authName = srs[0]
+		var err error
+		q.srid, err = strconv.Atoi(srs[1])
+		if err != nil {
+			web.BadRequest(w, r, "Invalid srsName.")
+			return false
+		}
+		if !validSrs(w, r, q.authName, q.srid) {
+			return false
+		}
+	} else {
+		q.srid = 4326
+		q.authName = "EPSG"
+		q.srsName = "EPSG:4326"
+	}
+
+	q.typeID = rl.Get("typeID")
+
+	if rl.Get("within") != "" {
+		q.within = strings.Replace(rl.Get("within"), "+", "", -1)
+		if !validPoly(w, r, q.within) {
+			return false
+		}
+	}
+
+	// delete any query params we know how to handle and there should be nothing left.
+	rl.Del("typeID")
+	rl.Del("days")
+	rl.Del("start")
+	rl.Del("srsName")
+	rl.Del("within")
+	if len(rl) > 0 {
+		web.BadRequest(w, r, "incorrect number of query params.")
+		return false
+	}
+
+	return validType(w, r, q.typeID)
+}
+
+func (q *spatialObs) Handle(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", web.V1CSV)
+
+	// Find the unit for the CSV header
+	var unit string
+	err := db.QueryRow("select symbol FROM fits.type join fits.unit using (unitPK) where typeID = $1", q.typeID).Scan(&unit)
+	if err == sql.ErrNoRows {
+		web.NotFound(w, r, "unit not found for typeID: "+q.typeID)
+		return
+	}
+	if err != nil {
+		web.ServiceUnavailable(w, r, err)
+		return
+	}
+
+	var d string
+	var rows *sql.Rows
+
+	if q.within == "" {
+		rows, err = db.Query(
+			`SELECT format('%s,%s,%s,%s,%s,%s,%s,%s,%s', networkid, siteid,  
+		ST_X(ST_Transform(location::geometry, $4)), ST_Y(ST_Transform(location::geometry, $4)),
+		height,ground_relationship, to_char(time, 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'), value, error) 
+		as csv FROM fits.observation join fits.site using (sitepk) join fits.network using (networkpk)
+		WHERE typepk = (SELECT typepk FROM fits.type WHERE typeid = $1) AND 
+		time >= $2 and time < $3 order by siteid asc`, q.typeID, q.start, q.end, q.srid)
+	} else {
+		rows, err = db.Query(
+			`SELECT format('%s,%s,%s,%s,%s,%s,%s,%s,%s', networkid, siteid,  
+		ST_X(ST_Transform(location::geometry, $4)), ST_Y(ST_Transform(location::geometry, $4)),
+		height,ground_relationship, to_char(time, 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'), value, error) 
+		as csv FROM fits.observation join fits.site using (sitepk) join fits.network using (networkpk)
+		WHERE typepk = (SELECT typepk FROM fits.type WHERE typeid = $1) 
+		AND  ST_Within(location::geometry, ST_GeomFromText($5, 4326))
+		AND time >= $2 and time < $3 order by siteid asc`, q.typeID, q.start, q.end, q.srid, q.within)
+	}
+	if err != nil {
+		// not sure what a transformation error would look like.
+		// Return any errors as a 404.  Could improve this by inspecting
+		// the error type to check for net dial errors that shoud 503.
+		web.NotFound(w, r, err.Error())
+		return
+	}
+	defer rows.Close()
+
+	var b bytes.Buffer
+	b.Write([]byte("networkID, siteID, X (" + q.srsName + "), Y (" + q.srsName + "), height, groundRelationship, date-time, " + q.typeID + " (" + unit + "), error (" + unit + ")"))
+	b.Write(eol)
+	for rows.Next() {
+		err := rows.Scan(&d)
+		if err != nil {
+			web.ServiceUnavailable(w, r, err)
+			return
+		}
+		b.Write([]byte(d))
+		b.Write(eol)
+	}
+	rows.Close()
+
+	w.Header().Set("Content-Disposition", `attachment; filename="FITS-`+q.typeID+`.csv"`)
+
+	web.OkBuf(w, r, &b)
+}
+
+// validSrs checks that the srs represented by auth and srid exists in the DB.
+func validSrs(w http.ResponseWriter, r *http.Request, auth string, srid int) bool {
+	var d string
+
+	err := db.QueryRow(`select auth_name FROM public.spatial_ref_sys where auth_name = $1
+		 AND srid = $2`, auth, srid).Scan(&d)
+	if err == sql.ErrNoRows {
+		web.BadRequest(w, r, "invalid srsName")
+		return false
+	}
+	if err != nil {
+		web.ServiceUnavailable(w, r, err)
+		return false
+	}
+
+	return true
+}
+
+func validPoly(w http.ResponseWriter, r *http.Request, poly string) bool {
+	var b bool
+
+	// There is a chance we will return an
+	// invalid polygon error for a DB DIal error but in that case something
+	// else is about to fail.  Postgis errors are hard to handle via an sql error.
+	err := db.QueryRow(`select ST_PolygonFromText($1, 4326) IS NOT NULL AS poly`, poly).Scan(&b)
+	if b {
+		return true
+	}
+
+	web.BadRequest(w, r, "invalid polygon: "+err.Error())
+	return false
+}

--- a/spatialObservations.go
+++ b/spatialObservations.go
@@ -18,33 +18,29 @@ var spatialObsD = &apidoc.Query{
 	Description: "Spatial observations as CSV",
 	Example:     "/observation?typeID=CO2-flux-e&start=2010-11-24T00:00:00Z&days=2&srsName=EPSG:27200&within=POLYGON((177.18+-37.52,177.19+-37.52,177.20+-37.53,177.18+-37.52))",
 	ExampleHost: exHost,
-	URI:         "/observation?typeID=(typeID)&start=(ISO8601 date time)&days=(int)&srsName=(CRS)&within=POLYGON((...))",
+	URI:         "/observation?typeID=(typeID)&start=(ISO8601 date time)&days=(int)&[srsName=(CRS)]&[within=POLYGON((...))]&[methodID=(methodID)]",
 	Params: map[string]template.HTML{
-		"typeID": `typeID for the observations to be retrieved e.g., <code>e</code>.`,
+		"typeID": typeIDDoc,
 		"days":   `The number of days of data to select from the start e.g., <code>1</code>.  Range is 1-7.`,
 		"start":  `the date time in ISO8601 format for the start of the time window for the request e.g., <code>2014-01-08T12:00:00Z</code>.`,
-		"srsName": `Optional (default EPSG:4326). Specify the <a href="http://en.wikipedia.org/wiki/Spatial_reference_system">spatial reference system</a> to project site coordinates to e.g., <code>EPSG:27200</code>
+		"srsName": optDoc + `  Default EPSG:4326. Specify the <a href="http://en.wikipedia.org/wiki/Spatial_reference_system">spatial reference system</a> to project site coordinates to e.g., <code>EPSG:27200</code>
 		(<a href="http://spatialreference.org/ref/epsg/nzgd49-new-zealand-map-grid/">New Zealand Map Grid</a>).  
 		Site locations are stored as a geography.  For projection they are cast to a geometry and then projected using 
 		<a href ="http://postgis.net/docs/ST_Transform.html">ST_Transform</a>.  Behaviour of projection is not defined outside the bounds of the SRS.  
 		For further details please refer to the PostGis manual: <a href="http://postgis.org/docs/using_postgis_dbmanagement.html#spatial_ref_sys">4.3.1. The SPATIAL_REF_SYS Table and Spatial Reference Systems</a>.`,
-		"within": `Optional.  Only return sites that fall within the polygon (uses <a href="http://postgis.net/docs/ST_Within.html">ST_Within</a>).  The polygon is
-		defined in <a href="http://en.wikipedia.org/wiki/Well-known_text">WKT</a> format
-		(WGS84).  The polygon must be topologically closed.  Spaces can be replaced with <code>+</code> or <a href="http://en.wikipedia.org/wiki/Percent-encoding">URL encoded</a> as <code>%20</code> e.g., 
-		<code>POLYGON((177.18+-37.52,177.19+-37.52,177.20+-37.53,177.18+-37.52))</code>.`,
-		"methodID": `Optional. Return only observations where the typeID has the provided methodID.  methodID must be a valid method
-		for the typeID.`,
+		"within":   optDoc + `  ` + withinDoc,
+		"methodID": optDoc + `  ` + methodIDDoc,
 	},
 	Props: map[string]template.HTML{
-		"column 1": `The networkID for the siteID e.g., <code>VO</code>.`,
-		"column 2": `The siteID  e.g., <code>WI034</code>.`,
+		"column 1": networkIDDoc,
+		"column 2": siteIDDoc,
 		"column 3": `The longitude (X) of the observation site.`,
 		"column 4": `The latitude (Y) of the observation site.`,
-		"column 5": `The height of the site (m).`,
-		"column 6": `The ground relationship (m) for the site.  Sites above ground level have a negative ground relationship.`,
-		"column 7": `The date-time of the observation in <a href="http://en.wikipedia.org/wiki/ISO_8601">ISO8601</a> format, UTC time zone.`,
-		"column 8": `The observation value.`,
-		"column 9": `The observation error.  0 is used for an unknown error.`,
+		"column 5": heightDoc,
+		"column 6": grelDoc,
+		"column 7": obsDTDoc,
+		"column 8": obsValDoc,
+		"column 9": obsErrDoc,
 	},
 }
 

--- a/type.go
+++ b/type.go
@@ -82,3 +82,21 @@ func validType(w http.ResponseWriter, r *http.Request, typeID string) bool {
 
 	return true
 }
+
+// validTypeMethod checks that the typeID and methodID exists in the DB
+// and are a valid combination.
+func validTypeMethod(w http.ResponseWriter, r *http.Request, typeID, methodID string) bool {
+	var d string
+
+	err := db.QueryRow("SELECT typepk FROM fits.type join fits.type_method using (typepk) join fits.method using (methodpk)  WHERE typeid = $1 and methodid = $2", typeID, methodID).Scan(&d)
+	if err == sql.ErrNoRows {
+		web.NotFound(w, r, "invalid methodID for typeID: "+methodID+" "+typeID)
+		return false
+	}
+	if err != nil {
+		web.ServiceUnavailable(w, r, err)
+		return false
+	}
+
+	return true
+}

--- a/type.go
+++ b/type.go
@@ -26,10 +26,10 @@ var typeQueryD = &apidoc.Query{
 		"none": `no query parameters are required.`,
 	},
 	Props: map[string]template.HTML{
-		"description": `a description of the type.`,
-		"name":        `a short name for the type.`,
-		"typeID":      `the type identifier.`,
-		"unit":        `the unit for the type.`,
+		"description": `Type description e.g., <code>displacement from initial position</code>`,
+		"name":        `Type name e.g., <code>east</code>`,
+		"typeID":      typeIDDoc,
+		"unit":        `Type unit e.g., <code>mm</code>.`,
 	},
 }
 


### PR DESCRIPTION
Lets the user query for Observations in space - returns CSV of site location and observation.
Allows coordinate reprojection.

I don't have a good way of letting users search for srsName (there are nearly 4000 supported by PostGIS).  http://spatialreference.org/ is as good a start as any.

@rumachan and @kfenaugh  - please could you review the functionality and documentation?  The code in this pull request is running against the live fits DB here: http://fits-wip-spatial.elasticbeanstalk.com/api-docs/endpoint/observation#spatialobservation

@junghao or @bpeng  - please could you review the code?  Please don't merge this yet - I will use the branch for other features.

@quiffman and @ozym  - thats a triggered quay build deployed into a cloned AWS EB environment.  Too easy.

Resolves #18.