### PR TITLE
Meta ingest automation

### DIFF
--- a/dapper/README.md
+++ b/dapper/README.md
@@ -2,5 +2,5 @@
 
 - SSH to the DB using:
 ```
-ssh -N -i ddooley.pem -J ec2-user@13.211.214.62 ec2-user@172.30.0.37 -L 5432:dev-dapper.cb9p6jbivbxx.ap-southeast-2.rds.amazonaws.com:5432
+ssh -N -i dev-jump.pem -J ubuntu@13.211.172.173 ubuntu@172.30.0.44 -L 5432:dev-dapper-fmp-p2.cb9p6jbivbxx.ap-southeast-2.rds.amazonaws.com:5432
 ```

--- a/dapper/cmd/dapper-api/data.go
+++ b/dapper/cmd/dapper-api/data.go
@@ -7,7 +7,6 @@ import (
 	"github.com/GeoNet/fits/dapper/dapperlib"
 	"github.com/GeoNet/fits/dapper/internal/valid"
 	"github.com/GeoNet/kit/weft"
-	"log"
 	"net/http"
 	"path"
 	"strconv"
@@ -138,7 +137,6 @@ func dataHandler(r *http.Request, h http.Header, b *bytes.Buffer) error {
 	results = results.Aggregate(dapperlib.DataAggrMethod(aggr), dapperlib.AUTO)
 
 	if results.Len() == 0 {
-		log.Println("empty results")
 		return valid.Error{
 			Code: http.StatusNotFound,
 			Err:  fmt.Errorf("no results for query"),
@@ -150,8 +148,6 @@ func dataHandler(r *http.Request, h http.Header, b *bytes.Buffer) error {
 
 func getDBFields(domain, key string, filter []string) ([]string, error) {
 	out := make([]string, 0)
-
-	log.Println(filter)
 
 	rows, err := db.Query("SELECT distinct(field) FROM dapper.records WHERE record_domain=$1 AND record_key=$2;", domain, key)
 	if err != nil {
@@ -191,8 +187,6 @@ func getDBFields(domain, key string, filter []string) ([]string, error) {
 
 func getDataLatest(domain, key string, latest int, filter []string) (dapperlib.Table, error) {
 	out := dapperlib.NewTable(domain, key)
-
-	log.Println("getDataLatest")
 
 	fields, err := getDBFields(domain, key, filter)
 	if err != nil {

--- a/dapper/cmd/dapper-api/data.go
+++ b/dapper/cmd/dapper-api/data.go
@@ -8,6 +8,7 @@ import (
 	"github.com/GeoNet/fits/dapper/internal/valid"
 	"github.com/GeoNet/kit/weft"
 	"net/http"
+	"os"
 	"path"
 	"strconv"
 	"strings"
@@ -27,11 +28,22 @@ type DomainConfig struct {
 
 func init() {
 	//TODO: This config should load from somewhere
-	domainMap["fdmp"] = DomainConfig{
-		s3bucket: "tf-dev-dapper-fdmp",
-		s3prefix: "data",
-		aggrtime: dapperlib.MONTH,
+	//NOTE: Currently this config doesn't change often so we hard coded here.
+	//		Add domain configuration pair (prod and dev) here when needed.
+	if os.Getenv("DOMAIN_ENV") == "prod" {
+		domainMap["fdmp"] = DomainConfig{
+			s3bucket: "tf-prod-dapper-fdmp",
+			s3prefix: "data",
+			aggrtime: dapperlib.MONTH,
+		}
+	} else {
+		domainMap["fdmp"] = DomainConfig{
+			s3bucket: "tf-dev-dapper-fdmp",
+			s3prefix: "data",
+			aggrtime: dapperlib.MONTH,
+		}
 	}
+
 }
 
 /*

--- a/dapper/cmd/dapper-api/env.list
+++ b/dapper/cmd/dapper-api/env.list
@@ -9,3 +9,6 @@ DB_SSLMODE=disable
 DB_CONN_TIMEOUT=5
 DB_MAX_IDLE_CONNS=30
 DB_MAX_OPEN_CONNS=30
+
+# Use "prod" for production environment
+DOMAIN_ENV=dev

--- a/dapper/cmd/dapper-db-meta-ingest/env.list
+++ b/dapper/cmd/dapper-db-meta-ingest/env.list
@@ -9,3 +9,6 @@ DB_SSLMODE=disable
 DB_CONN_TIMEOUT=5
 DB_MAX_IDLE_CONNS=30
 DB_MAX_OPEN_CONNS=30
+
+# S3 bucket notification queue for arrival of new metadata file 
+QUEUE_URL=https://sqs.ap-southeast-2.amazonaws.com/615890063537/test-dev-fmp-meta-notification

--- a/dapper/cmd/dapper-db-meta-ingest/main.go
+++ b/dapper/cmd/dapper-db-meta-ingest/main.go
@@ -1,217 +1,298 @@
 package main
 
 import (
+	"bytes"
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"github.com/GeoNet/fits/dapper/dapperlib"
+	"github.com/GeoNet/fits/dapper/internal/platform/s3"
+	"github.com/GeoNet/fits/dapper/internal/platform/sqs"
 	"github.com/GeoNet/kit/cfg"
+	"github.com/GeoNet/kit/metrics"
 	"github.com/golang/protobuf/proto"
 	_ "github.com/lib/pq"
-	"io/ioutil"
 	"log"
 	"os"
+	"path/filepath"
 	"sync"
 	"time"
 )
 
+const FMP_METADATA_FILE = "fmp_metadata.pb"
+
 var (
-	db *sql.DB
+	db        *sql.DB
+	s3Client  s3.S3
+	sqsClient sqs.SQS
+	queueURL  = os.Getenv("QUEUE_URL")
 )
+
+type notification struct {
+	s3.Event
+}
 
 func main() {
 	var err error
 
+	sqsClient, err = sqs.New()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	s3Client, err = s3.New()
+	if err != nil {
+		log.Fatalf("Failed creating S3 Client: %s", err)
+	}
+
+	var r sqs.Raw
+	var n notification
+
+	for {
+		// TODO - does this visibility time out make sense?
+		// we don't want the message to become visible again if there is
+		// still processing happening
+		r, err = sqsClient.Receive(queueURL, 900)
+		if err != nil {
+			log.Printf("problem receiving message, backing off: %s", err)
+			time.Sleep(time.Second * 20)
+			continue
+		}
+
+		err = metrics.DoProcess(&n, []byte(r.Body))
+		if err != nil {
+			log.Printf("problem processing message: %s", err)
+		}
+
+		err = sqsClient.Delete(queueURL, r.ReceiptHandle)
+		if err != nil {
+			log.Printf("problem deleting message, continuing: %s", err)
+		}
+	}
+}
+
+func (n *notification) Process(msg []byte) error {
+	err := json.Unmarshal(msg, n)
+	if err != nil {
+		return err
+	}
+
+	// add testing on the message.  If these return errors the message should
+	// go to the DLQ for further inspection.  Will catch errors such
+	// as SQS->SNS subscriptions being not for raw messages.S
+	if n.Records == nil {
+		return fmt.Errorf("got nil Records pointer in notification message")
+	}
+
+	if len(n.Records) == 0 {
+		return fmt.Errorf("got zero Records in notification message")
+	}
+
 	p, err := cfg.PostgresEnv()
 	if err != nil {
-		log.Fatalf("error reading DB config from the environment vars: %v", err)
+		return fmt.Errorf("error reading DB config from the environment vars: %v", err)
 	}
 
 	db, err = sql.Open("postgres", p.Connection())
 	if err != nil {
-		log.Fatalf("error with DB config: %v", err)
+		return fmt.Errorf("error with DB config: %v", err)
 	}
 
 	defer db.Close()
 
-	// For now we open from a file, TODO: Open from S3, probably on a queue with bucket notifications
-	if len(os.Args) != 2 {
-		log.Fatal("usage: dapper-db-meta-ingest [path to KeyMetadataList protobuf]")
-	}
-	openPath := os.Args[1]
-	log.Println("Opening: ", openPath)
-	pb, err := ioutil.ReadFile(openPath)
-	if err != nil {
-		log.Fatalf("failed to read input protobut: %v", err)
-	}
+	for _, v := range n.Records {
+		_, fileString := filepath.Split(v.S3.Object.Key)
 
-	var input dapperlib.KeyMetadataList
-	err = proto.Unmarshal(pb, &input)
-	if err != nil {
-		log.Fatalf("failed to unmarshal input protobuf: %v", err)
-	}
-
-	if len(input.Metadata) == 0 {
-		log.Fatalf("0 metadata keys to input")
-	}
-
-	tx, err := db.Begin()
-	if err != nil {
-		log.Fatalf("unable to begin transation: %v", err)
-	}
-
-	_, err = tx.Exec("DELETE FROM dapper.metadata WHERE record_domain=$1;", input.Metadata[0].Domain)
-	if err != nil {
-		_ = tx.Rollback()
-		log.Fatalf("failed to delete old metadata: %v", err)
-	}
-
-	_, err = tx.Exec("DELETE FROM dapper.metageom WHERE record_domain=$1;", input.Metadata[0].Domain)
-	if err != nil {
-		_ = tx.Rollback()
-		log.Fatalf("failed to delete old metadata: %v", err)
-	}
-
-	_, err = tx.Exec("DELETE FROM dapper.metarel WHERE record_domain=$1;", input.Metadata[0].Domain)
-	if err != nil {
-		_ = tx.Rollback()
-		log.Fatalf("failed to delete old metadata: %v", err)
-	}
-
-	metaStmt, err := tx.Prepare("INSERT INTO dapper.metadata (record_domain, record_key, field, value, timespan, istag) VALUES ($1, $2, $3, $4, TSTZRANGE($5, $6, '[)'), FALSE);")
-	if err != nil {
-		_ = tx.Rollback()
-		log.Fatalf("failed to prepare metadata statement: %v", err)
-	}
-
-	tagStmt, err := tx.Prepare("INSERT INTO dapper.metadata (record_domain, record_key, field, timespan, istag) VALUES ($1, $2, $3, TSTZRANGE($4, $5, '[)'), TRUE);")
-	if err != nil {
-		_ = tx.Rollback()
-		log.Fatalf("failed to prepare tag statement: %v", err)
-	}
-
-	locStmt, err := tx.Prepare("INSERT INTO dapper.metageom (record_domain, record_key, geom, timespan) VALUES ($1, $2, ST_MakePoint($3, $4), TSTZRANGE($5, $6, '[)'));")
-	if err != nil {
-		_ = tx.Rollback()
-		log.Fatalf("failed to preare loc statement: %v", err)
-	}
-
-	relStmt, err := tx.Prepare("INSERT INTO dapper.metarel (record_domain, from_key, to_key, rel_type, timespan) VALUES ($1, $2, $3, $4, TSTZRANGE($5, $6, '[)'));")
-	if err != nil {
-		_ = tx.Rollback()
-		log.Fatalf("failed to preare relation statement: %v", err)
-	}
-
-	sem := make(chan interface{}, 5)
-	wg := sync.WaitGroup{}
-
-	var txErr error
-
-	for i, km := range input.Metadata {
-		if (i+1)%100 == 0 || (i+1) == len(input.Metadata) {
-			log.Printf("Ingesting: %d/%d", i+1, len(input.Metadata))
+		if fileString != FMP_METADATA_FILE { // we only care about update for fmp metadata file update
+			continue
 		}
 
-		sem <- 0
-		wg.Add(1)
-		go func(km *dapperlib.KeyMetadata) {
-			defer func() {
-				<-sem
-				wg.Done()
-			}()
+		log.Println("Got notification for", v.S3.Object.Key)
+		buf := &bytes.Buffer{}
+		err := s3Client.Get(v.S3.Bucket.Name, v.S3.Object.Key, "", buf)
+		if err != nil {
+			return fmt.Errorf("Failed to get '%s': %v", v.S3.Object.Key, err)
+		}
 
-			for _, m := range km.Metadata {
-				for _, v := range m.Values {
-					if v.Span == nil {
-						tempErr := fmt.Errorf("metadata value %s/%s/%s/%s does not have a span", km.Domain, km.Key, m.Name, v.Value)
-						log.Println(tempErr)
-						txErr = tempErr
-						return
-					}
+		var input dapperlib.KeyMetadataList
+		err = proto.Unmarshal(buf.Bytes(), &input)
+		if err != nil {
+			return fmt.Errorf("failed to unmarshal input protobuf: %v", err)
+		}
 
-					start, end := time.Unix(v.Span.Start, 0), time.Unix(v.Span.End, 0)
+		if len(input.Metadata) == 0 {
+			return fmt.Errorf("0 metadata keys to input")
+		}
 
-					_, err = metaStmt.Exec(km.Domain, km.Key, m.Name, v.Value, start, end)
-					if err != nil {
-						tempErr := fmt.Errorf("%s/%s/%s: failed to add metadata entry: %v", km.Domain, km.Key, m.Name, err)
-						log.Println(tempErr)
-						txErr = tempErr
-						return
-					}
-				}
-			}
+		tx, err := db.Begin()
+		if err != nil {
+			return fmt.Errorf("unable to begin transation: %v", err)
+		}
 
-			for _, t := range km.Tags {
-				for _, s := range t.Span {
-					start, end := time.Unix(s.Start, 0), time.Unix(s.End, 0)
-
-					_, err = tagStmt.Exec(km.Domain, km.Key, t.Name, start, end)
-					if err != nil {
-						tempErr := fmt.Errorf("%s/%s/%s: failed to add tag entry: %v", km.Domain, km.Key, t.Name, err)
-						log.Println(tempErr)
-						txErr = tempErr
-						return
-					}
-				}
-			}
-
-			for _, p := range km.Location {
-				if p.Span == nil || p.Location == nil {
-					tempErr := fmt.Errorf("location entry for %s/%s does not contain Span AND Location", km.Domain, km.Key)
-					log.Println(tempErr)
-					txErr = tempErr
-					return
-				}
-				start, end := time.Unix(p.Span.Start, 0), time.Unix(p.Span.End, 0)
-
-				_, err = locStmt.Exec(km.Domain, km.Key, p.Location.Longitude, p.Location.Latitude, start, end)
-				if err != nil {
-					tempErr := fmt.Errorf("%s/%s: failed to add location entry: %v", km.Domain, km.Key, err)
-					log.Println(tempErr)
-					txErr = tempErr
-					return
-				}
-			}
-
-			for toKey, rs := range km.Relations {
-				// Makes sure if the keys exists
-				found := false
-				for _, k := range input.Metadata {
-					if toKey == k.Key {
-						found = true
-					}
-				}
-
-				if !found {
-					tempErr := fmt.Errorf("ToKey %s/%s not found in metadata", km.Domain, toKey)
-					log.Println(tempErr)
-					txErr = tempErr
-					return
-				}
-
-				for _, s := range rs.Spans {
-					start, end := time.Unix(s.Span.Start, 0), time.Unix(s.Span.End, 0)
-					_, err = relStmt.Exec(km.Domain, km.Key, toKey, s.RelType, start, end)
-					if err != nil {
-						tempErr := fmt.Errorf("%s/%s/%s failed to add metadata entry: %v", km.Domain, km.Key, toKey, err)
-						log.Println(tempErr)
-						txErr = tempErr
-						return
-					}
-				}
-			}
-		}(km)
-
-		if txErr != nil {
-			wg.Wait() //TODO: Do we need to have a timeout here?
+		_, err = tx.Exec("DELETE FROM dapper.metadata WHERE record_domain=$1;", input.Metadata[0].Domain)
+		if err != nil {
 			_ = tx.Rollback()
-			log.Fatalf("one or more keys failed to ingest, transaction rolled back")
+			return fmt.Errorf("failed to delete old metadata: %v", err)
+		}
+
+		_, err = tx.Exec("DELETE FROM dapper.metageom WHERE record_domain=$1;", input.Metadata[0].Domain)
+		if err != nil {
+			_ = tx.Rollback()
+			return fmt.Errorf("failed to delete old metadata: %v", err)
+		}
+
+		_, err = tx.Exec("DELETE FROM dapper.metarel WHERE record_domain=$1;", input.Metadata[0].Domain)
+		if err != nil {
+			_ = tx.Rollback()
+			return fmt.Errorf("failed to delete old metadata: %v", err)
+		}
+
+		metaStmt, err := tx.Prepare("INSERT INTO dapper.metadata (record_domain, record_key, field, value, timespan, istag) VALUES ($1, $2, $3, $4, TSTZRANGE($5, $6, '[)'), FALSE);")
+		if err != nil {
+			_ = tx.Rollback()
+			return fmt.Errorf("failed to prepare metadata statement: %v", err)
+		}
+
+		tagStmt, err := tx.Prepare("INSERT INTO dapper.metadata (record_domain, record_key, field, timespan, istag) VALUES ($1, $2, $3, TSTZRANGE($4, $5, '[)'), TRUE);")
+		if err != nil {
+			_ = tx.Rollback()
+			return fmt.Errorf("failed to prepare tag statement: %v", err)
+		}
+
+		locStmt, err := tx.Prepare("INSERT INTO dapper.metageom (record_domain, record_key, geom, timespan) VALUES ($1, $2, ST_MakePoint($3, $4), TSTZRANGE($5, $6, '[)'));")
+		if err != nil {
+			_ = tx.Rollback()
+			return fmt.Errorf("failed to preare loc statement: %v", err)
+		}
+
+		relStmt, err := tx.Prepare("INSERT INTO dapper.metarel (record_domain, from_key, to_key, rel_type, timespan) VALUES ($1, $2, $3, $4, TSTZRANGE($5, $6, '[)'));")
+		if err != nil {
+			_ = tx.Rollback()
+			return fmt.Errorf("failed to preare relation statement: %v", err)
+		}
+
+		sem := make(chan interface{}, 5)
+		wg := sync.WaitGroup{}
+		var txErr error
+		metaCount := 0
+		tagCount := 0
+		locCount := 0
+		relCount := 0
+
+		log.Printf("Start ingesting %d metadata", len(input.Metadata))
+
+		for _, km := range input.Metadata {
+			// if (i+1)%100 == 0 || (i+1) == len(input.Metadata) {
+			// 	log.Printf("Ingesting: %d/%d", i+1, len(input.Metadata))
+			// }
+			sem <- 0
+			wg.Add(1)
+			go func(km *dapperlib.KeyMetadata) {
+				defer func() {
+					<-sem
+					wg.Done()
+				}()
+
+				for _, m := range km.Metadata {
+					for _, v := range m.Values {
+						if v.Span == nil {
+							tempErr := fmt.Errorf("metadata value %s/%s/%s/%s does not have a span", km.Domain, km.Key, m.Name, v.Value)
+							log.Println(tempErr)
+							txErr = tempErr
+							return
+						}
+
+						start, end := time.Unix(v.Span.Start, 0), time.Unix(v.Span.End, 0)
+
+						_, err = metaStmt.Exec(km.Domain, km.Key, m.Name, v.Value, start, end)
+						if err != nil {
+							tempErr := fmt.Errorf("%s/%s/%s: failed to add metadata entry: %v", km.Domain, km.Key, m.Name, err)
+							log.Println(tempErr)
+							txErr = tempErr
+							return
+						}
+						metaCount++
+					}
+				}
+
+				for _, t := range km.Tags {
+					for _, s := range t.Span {
+						start, end := time.Unix(s.Start, 0), time.Unix(s.End, 0)
+
+						_, err = tagStmt.Exec(km.Domain, km.Key, t.Name, start, end)
+						if err != nil {
+							tempErr := fmt.Errorf("%s/%s/%s: failed to add tag entry: %v", km.Domain, km.Key, t.Name, err)
+							log.Println(tempErr)
+							txErr = tempErr
+							return
+						}
+						tagCount++
+					}
+				}
+
+				for _, p := range km.Location {
+					if p.Span == nil || p.Location == nil {
+						tempErr := fmt.Errorf("location entry for %s/%s does not contain Span AND Location", km.Domain, km.Key)
+						log.Println(tempErr)
+						txErr = tempErr
+						return
+					}
+					start, end := time.Unix(p.Span.Start, 0), time.Unix(p.Span.End, 0)
+
+					_, err = locStmt.Exec(km.Domain, km.Key, p.Location.Longitude, p.Location.Latitude, start, end)
+					if err != nil {
+						tempErr := fmt.Errorf("%s/%s: failed to add location entry: %v", km.Domain, km.Key, err)
+						log.Println(tempErr)
+						txErr = tempErr
+						return
+					}
+					locCount++
+				}
+
+				for toKey, rs := range km.Relations {
+					// Makes sure if the keys exists
+					found := false
+					for _, k := range input.Metadata {
+						if toKey == k.Key {
+							found = true
+						}
+					}
+
+					if !found {
+						tempErr := fmt.Errorf("ToKey %s/%s not found in metadata", km.Domain, toKey)
+						log.Println(tempErr)
+						txErr = tempErr
+						return
+					}
+
+					for _, s := range rs.Spans {
+						start, end := time.Unix(s.Span.Start, 0), time.Unix(s.Span.End, 0)
+						_, err = relStmt.Exec(km.Domain, km.Key, toKey, s.RelType, start, end)
+						if err != nil {
+							tempErr := fmt.Errorf("%s/%s/%s failed to add metadata entry: %v", km.Domain, km.Key, toKey, err)
+							log.Println(tempErr)
+							txErr = tempErr
+							return
+						}
+						relCount++
+					}
+				}
+			}(km)
+
+			if txErr != nil {
+				wg.Wait() //TODO: Do we need to have a timeout here?
+				_ = tx.Rollback()
+				return fmt.Errorf("one or more keys failed to ingest, transaction rolled back")
+			}
+		}
+		wg.Wait()
+
+		log.Printf("Done. %d metadata, %d tags, %d locality, and %d relations added", metaCount, tagCount, locCount, relCount)
+		err = tx.Commit()
+		if err != nil {
+			_ = tx.Rollback()
+			return fmt.Errorf("failed to commit transaction: %v", err)
 		}
 	}
-	wg.Wait()
-
-	err = tx.Commit()
-	if err != nil {
-		_ = tx.Rollback()
-		log.Fatalf("failed to commit transaction: %v", err)
-	}
+	return nil
 }

--- a/dapper/go.sum
+++ b/dapper/go.sum
@@ -1,3 +1,4 @@
+github.com/GeoNet/fits v0.0.0-20200302010520-694b45aa3ae9 h1:e+3opKMsyYwv+X0We73aQoSYeCYVwD3TQmhDjU7NyYw=
 github.com/GeoNet/kit v0.0.0-20200106002431-e839eed250ab h1:VZmGIFcIWA88MejKsJnPYyBp8DP2FMa8km9giY3s9PY=
 github.com/GeoNet/kit v0.0.0-20200106002431-e839eed250ab/go.mod h1:DVxQj3VMLvEdbZeqvKKdTC3sLnmDiTegESfoptv7QHM=
 github.com/aws/aws-sdk-go v1.25.35 h1:fe2tJnqty/v/50pyngKdNk/NP8PFphYDA1Z7N3EiiiE=


### PR DESCRIPTION
## Proposed Changes

Resolves #.

Changes proposed in this pull request:

`dapper-db-meta-ingest` takes `fmp_metadata.pb` from S3 generated by `fmp-metadata-collate`, store them into dapper database.

The logic in main.go didn't change. I simply change the program to a service to receive notification from S3, instead of load pb file locally.
## Production Changes

The following production changes are required to deploy these changes:

- None

## Review

Check the box that applies to this code review.  If necessary please seek help with adding a checklist guide for the reviewer.
When assigning the code review please consider the expertise needed to review the changes.

- [ ] This is a content (documentation, web page etc) only change.
- [X] This is a minor change (meta data, bug fix, improve test coverage etc).
- [ ] This is a larger change (new feature, significant refactoring etc).  Please use the code review guidelines to add a checklist below to guide the code reviewer.


### Code Review Guide

*Insert check list here if needed.*