### PR TITLE
Change parameter name to comply with other apps.

### DIFF
--- a/dapper/cmd/dapper-db-meta-ingest/env.list
+++ b/dapper/cmd/dapper-db-meta-ingest/env.list
@@ -11,4 +11,4 @@ DB_MAX_IDLE_CONNS=30
 DB_MAX_OPEN_CONNS=30
 
 # S3 bucket notification queue for arrival of new metadata file 
-QUEUE_URL=https://sqs.ap-southeast-2.amazonaws.com/615890063537/test-dev-fmp-meta-notification
+SQS_QUEUE_URL=https://sqs.ap-southeast-2.amazonaws.com/615890063537/test-dev-fmp-meta-notification

--- a/dapper/cmd/dapper-db-meta-ingest/main.go
+++ b/dapper/cmd/dapper-db-meta-ingest/main.go
@@ -25,7 +25,7 @@ var (
 	db        *sql.DB
 	s3Client  s3.S3
 	sqsClient sqs.SQS
-	queueURL  = os.Getenv("QUEUE_URL")
+	queueURL  = os.Getenv("SQS_QUEUE_URL")
 )
 
 type notification struct {


### PR DESCRIPTION
## Proposed Changes

All other dapper applications are using `SQS_QUEUE_URL` as parameter while only `dapper-db-meta-ingest` is using `QUEUE_URL`. This PR changes it.

Changes proposed in this pull request:

- 
-
-

## Production Changes

The following production changes are required to deploy these changes:

- None

## Review

Check the box that applies to this code review.  If necessary please seek help with adding a checklist guide for the reviewer.
When assigning the code review please consider the expertise needed to review the changes.

- [ ] This is a content (documentation, web page etc) only change.
- [x] This is a minor change (meta data, bug fix, improve test coverage etc).
- [ ] This is a larger change (new feature, significant refactoring etc).  Please use the code review guidelines to add a checklist below to guide the code reviewer.


### Code Review Guide

*Insert check list here if needed.*