### PR TITLE
Fix start/end time exclusive issue.

### DIFF
--- a/dapper/dapperlib/types.go
+++ b/dapper/dapperlib/types.go
@@ -437,7 +437,7 @@ func (t Table) Trim(start, end time.Time) Table {
 	rec := t.ToRecords(false)
 	out := NewTable(t.Domain, t.Key)
 	for _, r := range rec {
-		if r.Time.After(start) && r.Time.Before(end) {
+		if !r.Time.Before(start) && !r.Time.After(end) {
 			out.Append(r)
 		}
 	}


### PR DESCRIPTION
## Proposed Changes

Parameter `starttime` and `endtime` should be inclusive (`>=` and `<=`).

Changes proposed in this pull request:

- 
-
-

## Production Changes

The following production changes are required to deploy these changes:

- dapper-api

## Review

Check the box that applies to this code review.  If necessary please seek help with adding a checklist guide for the reviewer.
When assigning the code review please consider the expertise needed to review the changes.

- [ ] This is a content (documentation, web page etc) only change.
- [x] This is a minor change (meta data, bug fix, improve test coverage etc).
- [ ] This is a larger change (new feature, significant refactoring etc).  Please use the code review guidelines to add a checklist below to guide the code reviewer.


### Code Review Guide

*Insert check list here if needed.*