### PR TITLE
Shorten dapper-api soh/summary response time.

### DIFF
--- a/dapper/cmd/dapper-api/env.list
+++ b/dapper/cmd/dapper-api/env.list
@@ -22,5 +22,5 @@ DB_MAX_OPEN_CONNS=30
 # fits: in bucket tf-dev-fits with prefix internal.
 
 DOMAINS=test_api
-DOMAIN_BUCKETS=tf-dev-geonet-spool
+DOMAIN_BUCKETS=tf-dev-geonet-cache
 DOMAIN_PREFIXES=dapper/fmp-p2

--- a/dapper/cmd/dapper-api/soh.go
+++ b/dapper/cmd/dapper-api/soh.go
@@ -7,6 +7,7 @@ import (
 	"html"
 	"net/http"
 	"net/url"
+	"path/filepath"
 	"time"
 )
 
@@ -37,7 +38,10 @@ func summary(r *http.Request, h http.Header, b *bytes.Buffer) error {
 	for k, v := range domainMap {
 		var msg string
 		var class string
-		o, err := s3Client.ListObjects(v.s3bucket, v.s3prefix)
+		// we check if at least one archive (data older than 14 days) exists
+		d := time.Now().Truncate(24 * time.Hour).Add(-14 * 24 * time.Hour)
+		pfx := filepath.Join(v.s3prefix, d.Format("2006/january"))
+		o, err := s3Client.FirstObject(v.s3bucket, pfx)
 		if err != nil {
 			class = " class = \"tr error\""
 			msg = err.Error()

--- a/dapper/internal/platform/s3/s3.go
+++ b/dapper/internal/platform/s3/s3.go
@@ -158,6 +158,22 @@ func (s *S3) ListObjects(bucket, prefix string) ([]*s3.Object, error) {
 	return out.Contents, nil
 }
 
+//Returns only the first object in bucket/prefix
+func (s *S3) FirstObject(bucket, prefix string) ([]*s3.Object, error) {
+	input := &s3.ListObjectsInput{
+		Bucket:  aws.String(bucket),
+		Prefix:  aws.String(prefix),
+		MaxKeys: aws.Int64(1),
+	}
+
+	out, err := s.client.ListObjects(input)
+	if err != nil {
+		return nil, err
+	}
+
+	return out.Contents, nil
+}
+
 func (s *S3) Delete(bucket, key string) error {
 	input := s3.DeleteObjectInput{
 		Bucket: aws.String(bucket),


### PR DESCRIPTION
## Proposed Changes

This is regarding https://github.com/GeoNet/tickets/issues/10365.

Changes proposed in this pull request:

- Instead of querying everything in the dapper archive bucket, we now check only the latest archive directory in S3 
-
-

## Production Changes

The following production changes are required to deploy these changes:

dapper-api

## Review

Check the box that applies to this code review.  If necessary please seek help with adding a checklist guide for the reviewer.
When assigning the code review please consider the expertise needed to review the changes.

- [ ] This is a content (documentation, web page etc) only change.
- [x] This is a minor change (meta data, bug fix, improve test coverage etc).
- [ ] This is a larger change (new feature, significant refactoring etc).  Please use the code review guidelines to add a checklist below to guide the code reviewer.


### Code Review Guide

*Insert check list here if needed.*