### PR TITLE
Dapper send test change

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,6 +71,8 @@ jobs:
       aws-role-duration-seconds: "3600"
   go-build:
     if: ${{ contains(fromJSON('["workflow_call", "push", "pull_request"]'), github.event_name) && startsWith(github.repository, 'GeoNet/') != false }}
+    strategy:
+      matrix: ${{ fromJSON(needs.prepare.outputs.matrix) }}
     uses: GeoNet/Actions/.github/workflows/reusable-go-build-smoke-test.yml@main
     with:
       paths: ${{ inputs.paths }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,11 +71,9 @@ jobs:
       aws-role-duration-seconds: "3600"
   go-build:
     if: ${{ contains(fromJSON('["workflow_call", "push", "pull_request"]'), github.event_name) && startsWith(github.repository, 'GeoNet/') != false }}
-    strategy:
-      matrix: ${{ fromJSON(needs.prepare.outputs.matrix) }}
     uses: GeoNet/Actions/.github/workflows/reusable-go-build-smoke-test.yml@main
     with:
-      paths: ${{ inputs.paths }}
+      paths: ./cmd/...
       setup: |
         sudo apt-get update
         sudo apt-get install -y xsltproc

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,131 @@
+name: fits
+on:
+  push: {}
+  release:
+    types: [published]
+  workflow_dispatch: {}
+permissions:
+  packages: write
+  contents: write
+  pull-requests: write
+  id-token: write
+env:
+  FOLDER: ./cmd ./dapper
+  # doesn't have an ECR by that name; EXCLUDE is regex and is '|' separated (e.g: a|b|c)
+  EXCLUDE: '\?\?\?|dapper-send-test'
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      git-rev: ${{ steps.git-rev.outputs.git-rev }}
+      matrix: ${{ steps.set.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+      - uses: GeoNet/yq@bbe305500687a5fe8498d74883c17f0f06431ac4 # master
+      - id: git-rev
+        env:
+          GIT_SHA: ${{ github.sha }}
+        run: |
+          echo "git-rev=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+      - id: set
+        run: |
+          echo "matrix=$(grep -r 'package main' | sort | cut -d ':' -f1 | grep -Ewv "$EXCLUDE" - | grep '.go$' | xargs -n 1 dirname | sort | uniq | grep -v vendor | xargs -i echo './{}' | xargs | yq 'split(" ")|.[]|. as $folder |split("/") | {"target":.[-1],"folder":$folder,"sourcepath":"."} | (select(.folder|contains("dapper"))|.sourcepath)="./dapper"' -ojson | jq -rcM -s '{"include":.}')" >> $GITHUB_OUTPUT
+      - name: check output
+        run: |
+          jq . <<< '${{ steps.set.outputs.matrix }}'
+  build:
+    needs: prepare
+    strategy:
+      matrix: ${{ fromJSON(needs.prepare.outputs.matrix) }}
+    uses: GeoNet/Actions/.github/workflows/reusable-docker-build.yml@main
+    with:
+      setup: |
+        # this is an anti-pattern
+        mkdir -p "${{ fromJSON(toJSON(matrix)).folder }}/assets"
+        DOCKERFILE="${{ fromJSON(toJSON(matrix)).folder }}/${{ fromJSON(toJSON(matrix)).target }}.Dockerfile"
+        if [ -f "${{ fromJSON(toJSON(matrix)).folder }}/Dockerfile" ]; then
+          echo "using existing"
+          cp "${{ fromJSON(toJSON(matrix)).folder }}/Dockerfile" "$DOCKERFILE"
+        else
+          echo "copy-editing template"
+          cp ./Dockerfile_template "$DOCKERFILE"
+          cat << EOF >> "$DOCKERFILE"
+        CMD ["/${{ fromJSON(toJSON(matrix)).target }}"]
+        EOF
+        fi
+      context: .
+      buildArgs: |
+        BUILD=${{ fromJSON(toJSON(matrix)).target }}
+        GIT_COMMIT_SHA=${{ needs.prepare.outputs.git-rev }}
+        VERSION=git-${{ needs.prepare.outputs.git-rev }}
+        ASSET_DIR=${{ fromJSON(toJSON(matrix)).folder }}/assets
+        SOURCEPATH=${{ fromJSON(toJSON(matrix)).sourcepath }}
+      dockerfile: ${{ fromJSON(toJSON(matrix)).folder }}/${{ fromJSON(toJSON(matrix)).target }}.Dockerfile
+      imageName: ${{ fromJSON(toJSON(matrix)).target }}
+      platforms: linux/amd64
+      push: ${{ github.ref == 'refs/heads/main' }}
+      tags: latest,git-${{ needs.prepare.outputs.git-rev }}
+      registryOverride: 862640294325.dkr.ecr.ap-southeast-2.amazonaws.com
+      aws-region: ap-southeast-2
+      aws-role-arn-to-assume: arn:aws:iam::862640294325:role/github-actions-geonet-ecr-push
+      aws-role-duration-seconds: "3600"
+  go-build:
+    if: ${{ contains(fromJSON('["workflow_call", "push", "pull_request"]'), github.event_name) && startsWith(github.repository, 'GeoNet/') != false }}
+    uses: GeoNet/Actions/.github/workflows/reusable-go-build-smoke-test.yml@main
+    with:
+      paths: ${{ inputs.paths }}
+      setup: |
+        sudo apt-get update
+        sudo apt-get install -y xsltproc
+  gofmt:
+    if: ${{ contains(fromJSON('["workflow_call", "push", "pull_request"]'), github.event_name) && startsWith(github.repository, 'GeoNet/') != false }}
+    uses: GeoNet/Actions/.github/workflows/reusable-gofmt.yml@main
+  golangci-lint:
+    if: ${{ contains(fromJSON('["workflow_call", "push", "pull_request"]'), github.event_name) && startsWith(github.repository, 'GeoNet/') != false }}
+    uses: GeoNet/Actions/.github/workflows/reusable-golangci-lint.yml@main
+    with:
+      setup: |
+        sudo apt-get update
+        sudo apt-get install -y xsltproc
+  go-vet:
+    if: ${{ contains(fromJSON('["workflow_call", "push", "pull_request"]'), github.event_name) && startsWith(github.repository, 'GeoNet/') != false }}
+    uses: GeoNet/Actions/.github/workflows/reusable-go-vet.yml@main
+  go-test:
+    runs-on: ubuntu-latest
+    env:
+      AWS_REGION: ap-southeast-2
+    steps:
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+      - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
+        with:
+          go-version-file: go.mod
+          cache-dependency-path: go.sum
+          check-latest: true
+      - name: setup
+        run: |
+          sudo apt-get -yq update
+          sudo apt-get install -y xsltproc
+          docker \
+            run -d \
+            -p 5432:5432 \
+            -e POSTGRES_PASSWORD=test \
+            -e POSTGRES_USER=fits_w \
+            -e POSTGRES_DB=fits \
+            --name postgres \
+            docker.io/postgis/postgis:15-3.3-alpine
+          echo "Waiting until Postgres is ready..."
+          until nc -zv -w 1 127.0.0.1 5432; do
+          sleep 1s
+          done
+          sleep 5s
+          docker logs postgres
+          echo "Postgres is ready"
+          psql postgresql://fits_w:test@127.0.0.1/fits --file=./etc/ddl/drop-create-users.ddl
+          psql postgresql://fits_w:test@127.0.0.1/fits --file=./etc/ddl/create-db.ddl
+          psql postgresql://fits_w:test@127.0.0.1/fits --file=./etc/ddl/fits-create.ddl
+          psql postgresql://fits_w:test@127.0.0.1/fits --file=./etc/ddl/fits-functions.ddl
+          psql postgresql://fits_w:test@127.0.0.1/fits --file=./etc/ddl/user-permissions.ddl
+          psql postgresql://fits_w:test@127.0.0.1/fits --file=./etc/ddl/fits-test-data.ddl
+      - name: test
+        run: |
+          ./all.sh

--- a/Dockerfile_template
+++ b/Dockerfile_template
@@ -1,11 +1,10 @@
-ARG BUILDER_IMAGE=quay.io/geonet/golang:1.16-alpine
-ARG RUNNER_IMAGE=quay.io/geonet/go-scratch
+ARG BUILDER_IMAGE=ghcr.io/geonet/base-images/go:1.16
+ARG RUNNER_IMAGE=ghcr.io/geonet/base-images/static:latest
 ARG RUN_USER=nobody
 # Only support image based on AlpineLinux
 FROM ${BUILDER_IMAGE} as builder
 
 # Obtain ca-cert and tzdata, which we will add to the container
-RUN apk add --update ca-certificates tzdata
 
 # Project to build
 ARG BUILD
@@ -26,7 +25,6 @@ ENV GOOS linux
 ENV GOARCH amd64
 ENV CGO_ENABLED 0
 
-RUN echo 'nobody:x:65534:65534:Nobody:/:\' > /passwd
 RUN go install -a -installsuffix cgo -ldflags "-X main.Prefix=${BUILD}/${GIT_COMMIT_SHA}" /repo/cmd/${BUILD}
 
 FROM ${RUNNER_IMAGE}
@@ -35,7 +33,6 @@ ARG EXPOSE_PORT=8080
 EXPOSE $EXPOSE_PORT
 # Asset directory to copy to /assets
 # Add common resource for ssl and timezones from the build container
-COPY --from=builder /passwd /etc/passwd
 # Same ARG as before
 ARG BUILD
 # Need to make this an env for it to be interpolated by the shell

--- a/dapper/cmd/dapper-send-test/env.list
+++ b/dapper/cmd/dapper-send-test/env.list
@@ -1,2 +1,0 @@
-AWS_REGION=ap-southeast-2
-DAPPER_FH_STREAM=tf-dev-dapper-ingest-firehose

--- a/dapper/dapperlib/client_dev_test.go
+++ b/dapper/dapperlib/client_dev_test.go
@@ -1,27 +1,25 @@
 // +build devtest
 
-package main
+package dapperlib
 
 import (
 	"fmt"
-	"github.com/GeoNet/fits/dapper/dapperlib"
-	"log"
-	"os"
+	"testing"
 	"time"
 )
 
-var fhStream = os.Getenv("DAPPER_FH_STREAM")
+func TestSend(t *testing.T) {
+	var fhStream = "tf-dev-dapper-ingest-firehose"
 
-func main() {
-	sc, err := dapperlib.NewSendClient(fhStream)
+	sc, err := NewSendClient(fhStream)
 
 	if err != nil {
-		log.Fatalf("failed to create dapper SendClient: %v", err)
+		t.Fatalf("failed to create dapper SendClient: %v", err)
 	}
 
 	now := time.Now().Truncate(time.Minute)
 
-	vals := make([]dapperlib.Record, 0)
+	vals := make([]Record, 0)
 
 	dmns := []string{
 		"datalogger",
@@ -48,7 +46,7 @@ func main() {
 				for i := 0; i <= 60; i++ {
 					t := now.Add(-time.Minute * time.Duration(i))
 
-					vals = append(vals, dapperlib.Record{
+					vals = append(vals, Record{
 						Domain: d,
 						Key:    k,
 						Field:  f,
@@ -62,6 +60,6 @@ func main() {
 
 	err = sc.Send(vals)
 	if err != nil {
-		log.Fatalf("failed to send: %v", err)
+		t.Fatalf("failed to send: %v", err)
 	}
 }


### PR DESCRIPTION
The `dapper-send-test` is merely a dev test tool, and is causing GitHub Actions migration a problem.
Shouldn't be a standalone app under `dapper/cmd`. 
Moving it to where it should be.