### PR TITLE
Move dapper-send-test to dapperlib as a devtest tool.

### DIFF
--- a/dapper/cmd/dapper-send-test/env.list
+++ b/dapper/cmd/dapper-send-test/env.list
@@ -1,2 +1,0 @@
-AWS_REGION=ap-southeast-2
-DAPPER_FH_STREAM=tf-dev-dapper-ingest-firehose

--- a/dapper/dapperlib/client_dev_test.go
+++ b/dapper/dapperlib/client_dev_test.go
@@ -1,27 +1,25 @@
 // +build devtest
 
-package main
+package dapperlib
 
 import (
 	"fmt"
-	"github.com/GeoNet/fits/dapper/dapperlib"
-	"log"
-	"os"
+	"testing"
 	"time"
 )
 
-var fhStream = os.Getenv("DAPPER_FH_STREAM")
+func TestSend(t *testing.T) {
+	var fhStream = "tf-dev-dapper-ingest-firehose"
 
-func main() {
-	sc, err := dapperlib.NewSendClient(fhStream)
+	sc, err := NewSendClient(fhStream)
 
 	if err != nil {
-		log.Fatalf("failed to create dapper SendClient: %v", err)
+		t.Fatalf("failed to create dapper SendClient: %v", err)
 	}
 
 	now := time.Now().Truncate(time.Minute)
 
-	vals := make([]dapperlib.Record, 0)
+	vals := make([]Record, 0)
 
 	dmns := []string{
 		"datalogger",
@@ -48,7 +46,7 @@ func main() {
 				for i := 0; i <= 60; i++ {
 					t := now.Add(-time.Minute * time.Duration(i))
 
-					vals = append(vals, dapperlib.Record{
+					vals = append(vals, Record{
 						Domain: d,
 						Key:    k,
 						Field:  f,
@@ -62,6 +60,6 @@ func main() {
 
 	err = sc.Send(vals)
 	if err != nil {
-		log.Fatalf("failed to send: %v", err)
+		t.Fatalf("failed to send: %v", err)
 	}
 }


### PR DESCRIPTION
The `dapper-send-test` is merely a dev test tool, and is causing GitHub Actions migration a problem.
Shouldn't be a standalone app under `dapper/cmd`.
Moving it to where it should be.